### PR TITLE
fix: update federated credential subject format for main branch

### DIFF
--- a/infra/az-federated-credential-params/main.json
+++ b/infra/az-federated-credential-params/main.json
@@ -1,0 +1,9 @@
+{
+  "name": "main",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:B-Crolly/cst8918-w25-lab12:ref:refs/heads/main",
+  "description": "CST8918 Lab12 - GitHub Actions",
+  "audiences": [
+    "api://AzureADTokenExchange"
+  ]
+} 


### PR DESCRIPTION
though different from what the lab recommends, github's OICD seems to want a different format for running on the main branch "repo:B-Crolly/cst8918-w25-lab12:ref:refs/heads/main". I have updated our json file and remade the credential to match. workflows should now run successfully on main whether pulled or re-run manually.