### PR TITLE
feat: streamline workflow and fix terraform-apply job indentation

### DIFF
--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -65,12 +65,10 @@ jobs:
       uses: actions/checkout@v4
     
     # Azure Login with OIDC
-    # Using contributor app even for plan operations because static site resources 
-    # require listSecrets permissions that reader roles don't typically have
     - name: Azure Login
       uses: azure/login@v1
       with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID_CONTRIBUTOR }}
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     
@@ -153,4 +151,42 @@ jobs:
                 repo: context.repo.repo,
                 body: body
             })
+
+  # This will only run if the terraform plan has changes, and when the PR is approved and merged to main.
+  terraform-apply:
+    name: 'Terraform Apply'
+    if: github.ref == 'refs/heads/main' && needs.terraform-plan.outputs.tfplanExitCode == 2
+    runs-on: ubuntu-latest
+    environment: production
+    needs: [terraform-plan]
     
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # Azure Login with OIDC
+    - name: Azure Login
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID_CONTRIBUTOR }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: terraform init
+
+    # Download saved plan from artifacts  
+    - name: Download Terraform Plan
+      uses: actions/download-artifact@v4
+      with:
+        name: tfplan
+
+    # Terraform Apply
+    - name: Terraform Apply
+      run: terraform apply -auto-approve tfplan

--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -65,10 +65,12 @@ jobs:
       uses: actions/checkout@v4
     
     # Azure Login with OIDC
+    # Using contributor app for both plan and apply because static site resources 
+    # require elevated permissions (listSecrets) that reader roles don't have
     - name: Azure Login
       uses: azure/login@v1
       with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        client-id: ${{ secrets.AZURE_CLIENT_ID_CONTRIBUTOR }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     

--- a/.github/workflows/infra-ci-cd.yml
+++ b/.github/workflows/infra-ci-cd.yml
@@ -10,8 +10,12 @@ permissions:
   contents: read
   pull-requests: write
 
-# Only ARM_ACCESS_KEY is needed
+#These environment variables are used by the terraform azure provider to setup OIDC authenticate
 env:
+  ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID_CONTRIBUTOR }}"
+  ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+  ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
+  ARM_USE_OIDC: true
   ARM_ACCESS_KEY: "${{ secrets.ARM_ACCESS_KEY }}"
 
 defaults:


### PR DESCRIPTION
🔧 Workflow Setup & Structure

Got two workflows set up for our Terraform infrastructure:

1. **Static Tests** (`infra-static_tests.yml`):
   - Runs on every push
   - Does local validation only (no Azure access needed)
   - Checks formatting, validates config, and runs security scans
   - Great for quick feedback on PRs!

2. **CI/CD Pipeline** (`infra-ci-cd.yml`):
   - Runs on PRs and main branch
   - Three main jobs:
     - `tflint` - Catches common mistakes and best practice issues
     - `terraform-plan` - Shows what will change (posts plan to PR comments)
     - `terraform-apply` - Only runs on main after PR is merged
   - Using OIDC auth with Azure (more secure than storing creds)
   - Had to use contributor permissions because static sites need `listSecrets` access (I'm sure this is bad, please forgive me. I tried 
   adding narrower permissions for our reader registration but it didn't work).

Both workflows are now working properly with the right permissions and structure. Ready for review! 🚀